### PR TITLE
Change baseurl from docs.lgtm.co to lgtm.co

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://docs.lgtm.co/docs/"
+baseurl = "http://lgtm.co/docs/"
 languageCode = "en-us"
 title = "LGTM"
 theme = "default"


### PR DESCRIPTION
The docs seem to be hosted on lgtm.co/docs/ but the baseurl points to docs.lgtm.co/docs/ which has no DNS record.
