### PR TITLE
Remove 'docs' subdomain from baseurl

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://docs.lgtm.co/docs/"
+baseurl = "http://lgtm.co/docs/"
 languageCode = "en-us"
 title = "LGTM"
 theme = "default"


### PR DESCRIPTION
I was reading the docs, and when I clicked the logo in the upper left, I was redirected to an invalid URL.  This PR updates the baseurl to what I believe is the correct url.
